### PR TITLE
`update-home`: track hm `master` branch in inputs

### DIFF
--- a/examples/devos/flake.nix
+++ b/examples/devos/flake.nix
@@ -10,6 +10,7 @@
       # Track channels with commits tested and built by hydra
       nixos.url = "github:nixos/nixpkgs/nixos-22.05";
       latest.url = "github:nixos/nixpkgs/nixos-unstable";
+
       # For darwin hosts: it can be helpful to track this darwin-specific stable
       # channel equivalent to the `nixos-*` channels for NixOS. For one, these
       # channels are more likely to provide cached binaries for darwin systems.
@@ -24,7 +25,9 @@
       digga.inputs.home-manager.follows = "home";
       digga.inputs.deploy.follows = "deploy";
 
-      home.url = "github:nix-community/home-manager/release-22.05";
+      # FIXME: use 22.11 release
+      home.url = "github:nix-community/home-manager";
+      # home.url = "github:nix-community/home-manager/release-22.11";
       home.inputs.nixpkgs.follows = "nixos";
 
       darwin.url = "github:LnL7/nix-darwin";

--- a/examples/devos/modules/hm-system-defaults.nix
+++ b/examples/devos/modules/hm-system-defaults.nix
@@ -10,5 +10,8 @@
       xdg.configFile."nix/registry.json".text =
         config.environment.etc."nix/registry.json".text;
     }
+    {
+      home.stateVersion = "22.11";
+    }
   ];
 }

--- a/examples/groupByConfig/flake.nix
+++ b/examples/groupByConfig/flake.nix
@@ -19,7 +19,9 @@
     darwin.url = "github:LnL7/nix-darwin";
     darwin.inputs.nixpkgs.follows = "nixpkgs-darwin-stable";
 
-    home.url = "github:nix-community/home-manager/release-22.05";
+    # FIXME: use 22.11 release
+    home.url = "github:nix-community/home-manager";
+    # home.url = "github:nix-community/home-manager/release-22.11";
     home.inputs.nixpkgs.follows = "nixos";
   };
 

--- a/examples/groupByConfig/home/default.nix
+++ b/examples/groupByConfig/home/default.nix
@@ -4,4 +4,5 @@ let
 in
 {
   imports = [ (lib.importExportableModules ./modules) ];
+  home.stateVersion = "22.05";
 }

--- a/examples/hmOnly/flake.nix
+++ b/examples/hmOnly/flake.nix
@@ -3,10 +3,14 @@
 
   inputs = {
     nixos.url = "github:nixos/nixpkgs/nixos-22.05";
+
     digga.url = "github:divnix/digga";
     digga.inputs.nixpkgs.follows = "nixos";
     digga.inputs.home-manager.follows = "home";
-    home.url = "github:nix-community/home-manager/release-22.05";
+
+    # FIXME: use 22.11 release
+    home.url = "github:nix-community/home-manager";
+    # home.url = "github:nix-community/home-manager/release-22.11";
     home.inputs.nixpkgs.follows = "nixos";
   };
 

--- a/examples/hmOnly/home/default.nix
+++ b/examples/hmOnly/home/default.nix
@@ -12,4 +12,5 @@ in
     };
   };
   users = lib.rakeLeaves ./users;
+  home.stateVersion = "22.05";
 }

--- a/flake.lock
+++ b/flake.lock
@@ -162,30 +162,30 @@
       "inputs": {
         "nixpkgs": [
           "nixlib"
-        ]
+        ],
+        "utils": "utils_2"
       },
       "locked": {
-        "lastModified": 1656169755,
-        "narHash": "sha256-Nlnm4jeQWEGjYrE6hxi/7HYHjBSZ/E0RtjCYifnNsWk=",
+        "lastModified": 1657396086,
+        "narHash": "sha256-4cQ6hEuewWoFkTBlu211JGxPQQ1Zyli8oEq1cu7cVeA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4a3d01fb53f52ac83194081272795aa4612c2381",
+        "rev": "c645cc9f82c7753450d1fa4d1bc73b64960a9d7a",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-22.05",
         "repo": "home-manager",
         "type": "github"
       }
     },
     "latest": {
       "locked": {
-        "lastModified": 1657265485,
-        "narHash": "sha256-PUQ9C7mfi0/BnaAUX2R/PIkoNCb/Jtx9EpnhMBNrO/o=",
+        "lastModified": 1657356697,
+        "narHash": "sha256-sT38tcx7m0Quz+Uj6jzx+yRa2+EVW2C3cE0FkROXUzQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b39924fc7764c08ae3b51beef9a3518c414cdb7d",
+        "rev": "87e7965bbcdbac3d103e3ed14ff04f719a4f7a58",
         "type": "github"
       },
       "original": {
@@ -197,11 +197,11 @@
     },
     "nixlib": {
       "locked": {
-        "lastModified": 1656809537,
-        "narHash": "sha256-pwXBYG3ThN4ccJjvcdNdonQ8Wyv0y/iYdnuesiFUY1U=",
+        "lastModified": 1657414723,
+        "narHash": "sha256-mDy+kslt3q+LGnu2Ljlx6wsdZTIK163TBQX1ibGqKGc=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "40e271f69106323734b55e2ba74f13bebde324c0",
+        "rev": "b294cbe666a3e1ae2a869760966dea4440c7ca23",
         "type": "github"
       },
       "original": {
@@ -228,11 +228,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1657292830,
-        "narHash": "sha256-ldfVSTveWceDCmW6gf3B4kR6vwmz/XS80y5wsLLHFJU=",
+        "lastModified": 1657413868,
+        "narHash": "sha256-qDC9kUZhGhoDtOzhd6kIMUQHRZNys6/xsJAWrJB+gqU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "334ec8b503c3981e37a04b817a70e8d026ea9e84",
+        "rev": "7802f1b6479d6f04bea5cc94e8290ea61e210ecf",
         "type": "github"
       },
       "original": {
@@ -264,6 +264,21 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "0f8662f1319ad6abf89b3380dd2722369fc51ade",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_2": {
+      "locked": {
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,6 @@
 
   inputs =
     {
-      # Track channels with commits tested and built by hydra
       nixpkgs.url = "github:nixos/nixpkgs/nixos-22.05";
       latest.url = "github:nixos/nixpkgs/nixos-unstable";
       nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
@@ -19,8 +18,11 @@
       deploy.url = "github:serokell/deploy-rs";
       deploy.inputs.nixpkgs.follows = "nixpkgs";
 
-      home-manager.url = "github:nix-community/home-manager/release-22.05";
+      # FIXME: use 22.11 release
+      home-manager.url = "github:nix-community/home-manager";
+      # home-manager.url = "github:nix-community/home-manager/release-22.11";
       home-manager.inputs.nixpkgs.follows = "nixlib";
+      home-manager.inputs.utils.follows = "flake-utils-plus/flake-utils";
 
       darwin.url = "github:LnL7/nix-darwin";
       darwin.inputs.nixpkgs.follows = "nixpkgs";

--- a/src/mkFlake/outputs-builder.nix
+++ b/src/mkFlake/outputs-builder.nix
@@ -26,7 +26,6 @@ let
         {
           home = {
             inherit username homeDirectory;
-            stateVersion = "22.05";
           };
         }
       ] ++ config.home.exportedModules


### PR DESCRIPTION
re: https://github.com/divnix/digga/pull/472

I wanted to put this all in one branch in case others want to refer to it for the next while until the next home-manager release. Feel free to merge it into your branch.